### PR TITLE
Add CUDA run requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - tbb
 
   run:
+    - __cuda >={{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
     - python
     - numpy
     - tbb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set processor = "cpu" %}
 {% set name = "hoomd" %}
 {% set version = "2.9.4" %}
-{% set build = 1 %}
+{% set build = 2 %}
 {% set sha256 = "e09ea04d6c6326c12ccde51c949b91e132eddb2566bd6719556f54582029f3d6" %}
 {% set processor = "cpu" if cuda_compiler_version == "None" else "gpu" %}  # [linux64]
 {% set processor = "cpu" %}  # [not linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - tbb
 
   run:
-    - __cuda >={{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+    - __cuda >={{ cuda_compiler_version }}  # [linux64 and cuda_compiler_version != "None"]
     - python
     - numpy
     - tbb


### PR DESCRIPTION
This PR adds a run requirement of `__cuda` to ensure that CPU-only platforms select the CPU package by default. Note that this requires conda 4.8+ to work correctly.

Depends on https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/144

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.